### PR TITLE
Let dependabot ignore minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: "/aws"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "hashicorp/aws"
+        update-types: ["version-update:semver-minor"]
 
   - package-ecosystem: "terraform"
     directory: "/azure"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "hashicorp/azurerm"
+        update-types: ["version-update:semver-minor"]


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Minor updates are too noisy, so let's restrict to major versions only. Not entirely sure if the values for `dependency-name` are as dependabot expects them, but we will see.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
