### PR TITLE
Fix Prometheus repository configuration

### DIFF
--- a/aws/scripts/cloud-init-cratedb-rpm.tftpl
+++ b/aws/scripts/cloud-init-cratedb-rpm.tftpl
@@ -87,6 +87,31 @@ write_files:
     owner: root:root
     path: /etc/sysconfig/crate
     permissions: "0755"
+  - content: |
+      [prometheus-rpm_release]
+      name=prometheus-rpm_release
+      baseurl=https://packagecloud.io/prometheus-rpm/release/el/8/$basearch
+      repo_gpgcheck=0
+      gpgcheck=0
+      enabled=1
+      gpgkey=https://packagecloud.io/prometheus-rpm/release/gpgkey
+      sslverify=1
+      sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+      metadata_expire=300
+
+      [prometheus-rpm_release-source]
+      name=prometheus-rpm_release-source
+      baseurl=https://packagecloud.io/prometheus-rpm/release/el/8/SRPMS
+      repo_gpgcheck=0
+      gpgcheck=0
+      enabled=1
+      gpgkey=https://packagecloud.io/prometheus-rpm/release/gpgkey
+      sslverify=1
+      sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+      metadata_expire=300
+    owner: root:root
+    path: /etc/yum.repos.d/prometheus-rpm_release.repo
+    permissions: "0644"
 
 runcmd:
   - openssl pkcs12 -export -in /etc/crate/certificate.pem -inkey /etc/crate/private_key.pem -certfile /etc/crate/certificate.pem -out /etc/crate/keystore.p12 -passout pass:changeit
@@ -100,7 +125,6 @@ runcmd:
   - systemctl enable crate
   - systemctl start crate
   - bash /opt/deployment/finish.sh && rm -f /opt/deployment/finish.sh
-  - curl -s https://packagecloud.io/install/repositories/prometheus-rpm/release/script.rpm.sh | bash
   - yum install -y node_exporter
   - systemctl enable node_exporter.service
   - systemctl start node_exporter.service

--- a/aws/scripts/cloud-init-cratedb-tar.tftpl
+++ b/aws/scripts/cloud-init-cratedb-tar.tftpl
@@ -151,6 +151,31 @@ write_files:
     owner: root:root
     path: /usr/lib/systemd/system/crate.service
     permissions: "0444"
+  - content: |
+      [prometheus-rpm_release]
+      name=prometheus-rpm_release
+      baseurl=https://packagecloud.io/prometheus-rpm/release/el/8/$basearch
+      repo_gpgcheck=0
+      gpgcheck=0
+      enabled=1
+      gpgkey=https://packagecloud.io/prometheus-rpm/release/gpgkey
+      sslverify=1
+      sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+      metadata_expire=300
+
+      [prometheus-rpm_release-source]
+      name=prometheus-rpm_release-source
+      baseurl=https://packagecloud.io/prometheus-rpm/release/el/8/SRPMS
+      repo_gpgcheck=0
+      gpgcheck=0
+      enabled=1
+      gpgkey=https://packagecloud.io/prometheus-rpm/release/gpgkey
+      sslverify=1
+      sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+      metadata_expire=300
+    owner: root:root
+    path: /etc/yum.repos.d/prometheus-rpm_release.repo
+    permissions: "0644"
 
 runcmd:
   - groupadd -r crate
@@ -170,7 +195,6 @@ runcmd:
   - systemctl enable crate
   - systemctl start crate
   - bash /opt/deployment/finish.sh && rm -f /opt/deployment/finish.sh
-  - curl -s https://packagecloud.io/install/repositories/prometheus-rpm/release/script.rpm.sh | bash
   - yum install -y node_exporter
   - systemctl enable node_exporter.service
   - systemctl start node_exporter.service

--- a/aws/scripts/cloud-init-utilities.tftpl
+++ b/aws/scripts/cloud-init-utilities.tftpl
@@ -108,12 +108,36 @@ write_files:
       basic_auth_users:
         PROMETHEUS_OPTS='--config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus/data --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles --web.config.file=/etc/prometheus/web.yml'
     path: /etc/default/prometheus
+  - content: |
+      [prometheus-rpm_release]
+      name=prometheus-rpm_release
+      baseurl=https://packagecloud.io/prometheus-rpm/release/el/9/$basearch
+      repo_gpgcheck=0
+      gpgcheck=0
+      enabled=1
+      gpgkey=https://packagecloud.io/prometheus-rpm/release/gpgkey
+      sslverify=1
+      sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+      metadata_expire=300
+
+      [prometheus-rpm_release-source]
+      name=prometheus-rpm_release-source
+      baseurl=https://packagecloud.io/prometheus-rpm/release/el/9/SRPMS
+      repo_gpgcheck=0
+      gpgcheck=0
+      enabled=1
+      gpgkey=https://packagecloud.io/prometheus-rpm/release/gpgkey
+      sslverify=1
+      sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+      metadata_expire=300
+    owner: root:root
+    path: /etc/yum.repos.d/prometheus-rpm_release.repo
+    permissions: "0644"
 
 runcmd:
   - /root/node.sh
   - mv /root/.env /home/ec2-user/nodeIngestBench/.env
   - chown ec2-user:ec2-user /home/ec2-user/nodeIngestBench/.env
-  - curl -s https://packagecloud.io/install/repositories/prometheus-rpm/release/script.rpm.sh | bash
   - dnf install -y prometheus2
   - systemctl enable prometheus.service
   - systemctl start prometheus.service


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The automatic script provided by the RPM repository maintainers (`https://packagecloud.io/install/repositories/prometheus-rpm/release/script.rpm.sh`) used to be able to figure out a matching repository configuration for Prometheus on Amazon Linux.
There are no packages for Amazon Linux directly, but the ones for `el/8` work for Amazon Linux 2, and `el/9` works for Amazon Linux 2023. The CrateDB nodes are still restricted to Amazon Linux 2 due to https://github.com/crate/distribute/issues/557.

Instead of relying on the upstream `script.rpm.sh`, this change makes the repository choice explicit, no longer depending on any automatic detection.

Fixes #84 

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
