### PR TITLE
Various Azure improvements (Pyroscope)

### DIFF
--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -31,6 +31,7 @@ resource "tls_self_signed_cert" "ssl" {
 }
 
 data "cloudinit_config" "config" {
+  count         = var.crate.cluster_size
   gzip          = true
   base64_encode = true
 
@@ -47,12 +48,14 @@ data "cloudinit_config" "config" {
         crate_heap_size        = var.crate.heap_size
         crate_cluster_name     = var.crate.cluster_name
         crate_cluster_size     = var.crate.cluster_size
+        crate_node_name        = "cratedb-${count.index}"
         crate_nodes_ips        = indent(12, yamlencode(aws_network_interface.interface[*].private_ip))
         crate_ssl_enable       = var.crate.ssl_enable
         crate_protocol         = var.crate.ssl_enable ? "https" : "http"
         crate_ssl_certificate  = base64encode(tls_self_signed_cert.ssl.cert_pem)
         crate_ssl_private_key  = base64encode(tls_private_key.ssl.private_key_pem)
         cratedb_user_settings  = indent(8, yamlencode(var.cratedb_settings))
+        pyroscope_server       = var.pyroscope_server
       }
     )
   }
@@ -160,7 +163,7 @@ resource "aws_instance" "cratedb_node" {
   instance_type        = var.instance_type
   key_name             = var.ssh_keypair
   availability_zone    = element(var.availability_zones, count.index)
-  user_data_base64     = data.cloudinit_config.config.rendered
+  user_data_base64     = data.cloudinit_config.config[count.index].rendered
   monitoring           = var.enable_utility_vm
   iam_instance_profile = var.instance_profile
 

--- a/aws/scripts/cloud-init-cratedb-rpm.tftpl
+++ b/aws/scripts/cloud-init-cratedb-rpm.tftpl
@@ -72,6 +72,8 @@ write_files:
         cluster.initial_master_nodes:
             ${crate_nodes_ips}
 
+        node.name: ${crate_node_name}
+
         gateway.expected_data_nodes: ${crate_cluster_size}
         gateway.recover_after_data_nodes: ${crate_cluster_size}
 
@@ -94,7 +96,13 @@ write_files:
       CRATE_HEAP_SIZE=${crate_heap_size}
 
       # Additional Java options
-      CRATE_JAVA_OPTS="-javaagent:/usr/share/crate/crate-jmx-exporter-1.2.4.jar=8080"
+      CRATE_JAVA_OPTS="-javaagent:/usr/share/crate/crate-jmx-exporter-1.2.4.jar=8080%{if pyroscope_server != ""} -javaagent:/usr/share/crate/pyroscope.jar%{endif}"
+
+      %{if pyroscope_server != ""}
+      PYROSCOPE_APPLICATION_NAME=${crate_node_name}
+      PYROSCOPE_SERVER_ADDRESS=${pyroscope_server}
+      PYROSCOPE_PROFILER_ALLOC=512k
+      %{endif}
     owner: root:root
     path: /etc/default/crate
     permissions: "0755"
@@ -117,6 +125,7 @@ runcmd:
   - chown -R crate:crate /opt/data /etc/crate
   - chmod 700 /opt/data
   - curl --output-dir /usr/share/crate -O https://repo1.maven.org/maven2/io/crate/crate-jmx-exporter/1.2.4/crate-jmx-exporter-1.2.4.jar
+  - curl --output-dir /usr/share/crate -O https://github.com/grafana/pyroscope-java/releases/download/v2.5.2/pyroscope.jar
   - systemctl enable crate
   - systemctl start crate
   - bash /opt/deployment/user_provisioning.sh "${crate_protocol}" "${crate_user}" "${crate_pass}" && rm -f /opt/deployment/user_provisioning.sh

--- a/aws/scripts/cloud-init-cratedb-tar.tftpl
+++ b/aws/scripts/cloud-init-cratedb-tar.tftpl
@@ -63,6 +63,8 @@ write_files:
         cluster.initial_master_nodes:
             ${crate_nodes_ips}
 
+        node.name: ${crate_node_name}
+
         gateway.expected_data_nodes: ${crate_cluster_size}
         gateway.recover_after_data_nodes: ${crate_cluster_size}
 
@@ -90,7 +92,13 @@ write_files:
       CRATE_HEAP_SIZE=${crate_heap_size}
 
       # Additional Java options
-      CRATE_JAVA_OPTS="-javaagent:/opt/crate/crate-jmx-exporter-1.2.4.jar=8080"
+      CRATE_JAVA_OPTS="-javaagent:/opt/crate/crate-jmx-exporter-1.2.4.jar=8080%{if pyroscope_server != ""} -javaagent:/opt/crate/pyroscope.jar%{endif}"
+
+      %{if pyroscope_server != ""}
+      PYROSCOPE_APPLICATION_NAME=${crate_node_name}
+      PYROSCOPE_SERVER_ADDRESS=${pyroscope_server}
+      PYROSCOPE_PROFILER_ALLOC=512k
+      %{endif}
     owner: root:root
     path: /etc/default/crate
     permissions: "0755"
@@ -169,6 +177,7 @@ runcmd:
   - mv -n crate-*/* /opt/crate
   - mv crate-*/config/log4j2.properties /opt/crate/config
   - curl --output-dir /opt/crate -O https://repo1.maven.org/maven2/io/crate/crate-jmx-exporter/1.2.4/crate-jmx-exporter-1.2.4.jar
+  - curl --output-dir /opt/crate -O https://github.com/grafana/pyroscope-java/releases/download/v2.5.2/pyroscope.jar
   - chown -R crate:crate /opt/crate
   - systemctl daemon-reload
   - systemctl enable crate

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -179,3 +179,9 @@ variable "prometheus_ssl" {
   default     = true
   description = "If true, a self-signed SSL certificate will be generated for accessing Prometheus."
 }
+
+variable "pyroscope_server" {
+  type        = string
+  default     = ""
+  description = "An optional Pyroscope server URL to push metrics to"
+}

--- a/azure/README.md
+++ b/azure/README.md
@@ -61,6 +61,9 @@ The main setup consists of the following steps:
         # Username to connect via SSH to the nodes
         user = "cratedb-vmadmin"
       }
+
+      # The path to your existing SSH public key
+      ssh_public_key_path = "/home/user/.ssh/id_rsa.pub"
     }
 
     output "cratedb" {

--- a/azure/README.md
+++ b/azure/README.md
@@ -91,5 +91,4 @@ Please note that it might take a couple of minutes before VMs are fully provisio
 
 ## Accessing Azure VMs
 
-Azure VMs are not directly accessible as they have private IP addresses. To connect to them, use a [bastion host](https://docs.microsoft.com/en-us/azure/bastion/quickstart-host-portal). Please see `terraform output -json` for the user name and private key which are valid for all VMs.
-In the default configuration, SSH access is enabled in the network security group. It can be disabled if needed via the `vm.ssh_access` variable.
+Azure VMs are assigned a public IP address for easily connecting to them. In the default configuration, SSH access is enabled in the network security group. It can be disabled if needed via the `vm.ssh_access` variable.

--- a/azure/network.tf
+++ b/azure/network.tf
@@ -52,6 +52,30 @@ resource "azurerm_network_security_group" "nsg" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
+
+  security_rule {
+    name                       = "CrateDB-JMX"
+    priority                   = 103
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "8080"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "node_exporter"
+    priority                   = 104
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "9100"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "sn_nsg" {

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -23,9 +23,3 @@ output "azurevm_username" {
   value       = var.vm.user
   description = "User name to connect via SSH to the Azure VMs"
 }
-
-output "azurevm_private_key" {
-  value       = tls_private_key.ssh_key.private_key_pem
-  sensitive   = true
-  description = "Private key to connect via SSH to the Azure VMs"
-}

--- a/azure/scripts/cloud-init-cratedb.tftpl
+++ b/azure/scripts/cloud-init-cratedb.tftpl
@@ -73,6 +73,7 @@ write_files:
                 method: password
         network.host: _site_, _local_
         cluster.name: ${crate_cluster_name}
+        node.name: ${crate_node_name}
         discovery.seed_hosts:
             ${crate_nodes_ips}
         cluster.initial_master_nodes:
@@ -94,7 +95,13 @@ write_files:
       CRATE_HEAP_SIZE=${crate_heap_size}g
 
       # Additional Java options
-      CRATE_JAVA_OPTS="-javaagent:/usr/share/crate/crate-jmx-exporter-1.2.4.jar=8080"
+      CRATE_JAVA_OPTS="-javaagent:/usr/share/crate/crate-jmx-exporter-1.2.4.jar=8080%{if pyroscope_server != ""} -javaagent:/usr/share/crate/pyroscope.jar%{endif}"
+
+      %{if pyroscope_server != ""}
+      PYROSCOPE_APPLICATION_NAME=${crate_node_name}
+      PYROSCOPE_SERVER_ADDRESS=${pyroscope_server}
+      PYROSCOPE_PROFILER_ALLOC=512k
+      %{endif}
     owner: root:root
     path: /etc/default/crate
     permissions: "0755"
@@ -106,6 +113,7 @@ runcmd:
   - apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y crate
   - systemctl enable crate
   - curl --output-dir /usr/share/crate -O https://repo1.maven.org/maven2/io/crate/crate-jmx-exporter/1.2.4/crate-jmx-exporter-1.2.4.jar
+  - curl --output-dir /usr/share/crate -O https://github.com/grafana/pyroscope-java/releases/download/v2.5.2/pyroscope.jar
   - chown -R crate:crate /opt/data
   - chmod 700 /opt/data
   - systemctl start crate

--- a/azure/scripts/cloud-init-cratedb.tftpl
+++ b/azure/scripts/cloud-init-cratedb.tftpl
@@ -13,19 +13,25 @@ packages:
   - openssl
   - prometheus-node-exporter
 
-disk_setup:
-  /dev/disk/azure/scsi1/lun1:
-    table_type: gpt
-    layout: True
-    overwrite: True
+bootcmd:
+  - mkdir -p /opt/data
+  - |
+    # Wait for the data disk to become available
+    for i in $(seq 1 60); do
+      if [ -e /dev/disk/azure/data/by-lun/1 ]; then
+        break
+      fi
+      udevadm settle || true
+      sleep 2
+    done
 
 fs_setup:
-  - device: /dev/disk/azure/scsi1/lun1
-    partition: 1
+  - device: /dev/disk/azure/data/by-lun/1
     filesystem: xfs
+    overwrite: false
 
 mounts:
-  - ["/dev/disk/azure/scsi1/lun1-part1", "/opt/data", auto, "defaults,noexec,nofail"]
+  - ["/dev/disk/azure/data/by-lun/1", "/opt/data", "xfs", "defaults,noexec,nofail", "0", "2"]
 
 apt:
   sources:
@@ -33,7 +39,6 @@ apt:
       keyid: '90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB'
       keyserver: 'https://cdn.crate.io/downloads/debian/DEB-GPG-KEY-crate'
       source: 'deb [signed-by=$KEY_FILE] https://cdn.crate.io/downloads/debian/stable/ default main'
-
 
 write_files:
   - content: !!binary |
@@ -95,12 +100,11 @@ write_files:
     permissions: "0755"
 
 runcmd:
-  - mkdir -p /opt/data
-  - chmod 777 /opt/data
   - openssl pkcs12 -export -in /etc/crate/certificate.pem -inkey /etc/crate/private_key.pem -certfile /etc/crate/certificate.pem -out /etc/crate/keystore.p12 -passout pass:changeit
   - chmod 755 /etc/crate/keystore.p12
   - rm /etc/crate/certificate.pem && rm /etc/crate/private_key.pem
   - apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y crate
+  - systemctl enable crate
   - curl --output-dir /usr/share/crate -O https://repo1.maven.org/maven2/io/crate/crate-jmx-exporter/1.2.4/crate-jmx-exporter-1.2.4.jar
   - chown -R crate:crate /opt/data
   - chmod 700 /opt/data

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -58,3 +58,9 @@ variable "ssh_public_key_path" {
   type        = string
   description = "The path to an existing SSH public key to use for authentication when connecting via SSH to the VMs"
 }
+
+variable "pyroscope_server" {
+  type        = string
+  default     = ""
+  description = "An optional Pyroscope server URL to push metrics to"
+}

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -53,3 +53,8 @@ variable "subscription_id" {
   type        = string
   description = "The Azure subscription ID"
 }
+
+variable "ssh_public_key_path" {
+  type        = string
+  description = "The path to an existing SSH public key to use for authentication when connecting via SSH to the VMs"
+}

--- a/azure/vm.tf
+++ b/azure/vm.tf
@@ -27,6 +27,7 @@ resource "tls_self_signed_cert" "ssl" {
 }
 
 data "cloudinit_config" "config" {
+  count         = var.crate.cluster_size
   gzip          = true
   base64_encode = true
 
@@ -41,10 +42,12 @@ data "cloudinit_config" "config" {
         crate_heap_size       = var.crate.heap_size_gb
         crate_cluster_name    = var.crate.cluster_name
         crate_cluster_size    = var.crate.cluster_size
+        crate_node_name       = "cratedb-${count.index}"
         crate_nodes_ips       = indent(12, yamlencode(azurerm_network_interface.crate[*].private_ip_address))
         crate_ssl_enable      = var.crate.ssl_enable
         crate_ssl_certificate = base64encode(tls_self_signed_cert.ssl.cert_pem)
         crate_ssl_private_key = base64encode(tls_private_key.ssl.private_key_pem)
+        pyroscope_server      = var.pyroscope_server
       }
     )
   }
@@ -95,7 +98,7 @@ resource "azurerm_linux_virtual_machine" "crate" {
 
   admin_username                  = var.vm.user
   disable_password_authentication = true
-  custom_data                     = data.cloudinit_config.config.rendered
+  custom_data                     = data.cloudinit_config.config[count.index].rendered
 
   source_image_reference {
     publisher = "canonical"

--- a/azure/vm.tf
+++ b/azure/vm.tf
@@ -81,11 +81,6 @@ resource "azurerm_network_interface_backend_address_pool_association" "main" {
   backend_address_pool_id = azurerm_lb_backend_address_pool.main.id
 }
 
-resource "tls_private_key" "ssh_key" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
-
 resource "azurerm_linux_virtual_machine" "crate" {
   count = var.crate.cluster_size
 
@@ -117,7 +112,7 @@ resource "azurerm_linux_virtual_machine" "crate" {
 
   admin_ssh_key {
     username   = var.vm.user
-    public_key = tls_private_key.ssh_key.public_key_openssh
+    public_key = file(var.ssh_public_key_path)
   }
 
   tags = {

--- a/test/cratedb.go
+++ b/test/cratedb.go
@@ -5,13 +5,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/http-helper"
-	"github.com/gruntwork-io/terratest/modules/testing"
-	"github.com/stretchr/testify/assert"
+	"testing"
 	"time"
+
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/stretchr/testify/assert"
 )
 
-func RunCrateDBQuery(t testing.TestingT, clusterUrl string, username string, password string) map[string]interface{} {
+func RunCrateDBQuery(t *testing.T, clusterUrl string, username string, password string) map[string]any {
 	credentials := fmt.Sprintf("%s:%s", username, password)
 
 	requestHeaders := map[string]string{
@@ -19,19 +20,20 @@ func RunCrateDBQuery(t testing.TestingT, clusterUrl string, username string, pas
 		"Authorization": fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(credentials))),
 	}
 
-	bodyJson := http_helper.HTTPDoWithRetry(
+	bodyJson := http_helper.HTTPDoWithRetryContext(
 		t,
+		t.Context(),
 		"POST",
 		fmt.Sprintf("%s/_sql", clusterUrl),
 		[]byte(`{"stmt":"SELECT COUNT(*) AS nodes FROM sys.nodes"}`),
 		requestHeaders,
 		200,           // expected status code
-		20,            // retries
+		30,            // retries
 		time.Second*5, // sleep between retries
 		&tls.Config{InsecureSkipVerify: true},
 	)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err := json.Unmarshal([]byte(bodyJson), &body)
 	assert.Nil(t, err)
 

--- a/test/terraform_aws_test.go
+++ b/test/terraform_aws_test.go
@@ -2,15 +2,18 @@ package test
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/environment"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func TestTerraformAws(t *testing.T) {
+	t.Parallel()
+
 	environment.RequireEnvVar(t, "AWS_TEST_REGION")
 	environment.RequireEnvVar(t, "AWS_TEST_VPC_ID")
 	environment.RequireEnvVar(t, "AWS_TEST_SSH_KEYPAIR")
@@ -19,23 +22,25 @@ func TestTerraformAws(t *testing.T) {
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../aws",
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"region":             os.Getenv("AWS_TEST_REGION"),
 			"vpc_id":             os.Getenv("AWS_TEST_VPC_ID"),
 			"ssh_keypair":        os.Getenv("AWS_TEST_SSH_KEYPAIR"),
 			"subnet_ids":         os.Getenv("AWS_TEST_SUBNET_IDS"),
 			"availability_zones": os.Getenv("AWS_TEST_AVAILABILITY_ZONES"),
-			"config":             fmt.Sprintf("{project_name = \"%s\", environment = \"test\", owner = \"Crate.IO\", team = \"Test Team\"}", random.UniqueId()),
-			"crate":              "{heap_size_gb = 2, cluster_name = \"cratedb\", cluster_size = 2, ssl_enable = true}",
+			"config":             fmt.Sprintf("{project_name = \"%s\", environment = \"test\", owner = \"Crate.IO\", team = \"Test Team\"}", random.UniqueID()),
+			"crate":              "{heap_size = \"2g\", cluster_name = \"cratedb\", cluster_size = 2, ssl_enable = true}",
 		},
 	})
 
-	defer terraform.Destroy(t, terraformOptions)
-	terraform.InitAndApply(t, terraformOptions)
+	// Clean up resources with "terraform destroy" at the end of the test.
+	defer terraform.DestroyContext(t, t.Context(), terraformOptions)
 
-	clusterUrl := terraform.Output(t, terraformOptions, "cratedb_application_url")
-	cratedbUsername := terraform.Output(t, terraformOptions, "cratedb_username")
-	cratedbPassword := terraform.Output(t, terraformOptions, "cratedb_password")
+	terraform.InitAndApplyContext(t, t.Context(), terraformOptions)
+
+	clusterUrl := terraform.OutputContext(t, t.Context(), terraformOptions, "cratedb_application_url")
+	cratedbUsername := terraform.OutputContext(t, t.Context(), terraformOptions, "cratedb_username")
+	cratedbPassword := terraform.OutputContext(t, t.Context(), terraformOptions, "cratedb_password")
 
 	// we don't validate the certificate explicitly, but check that the URL includes https
 	assert.Regexp(t, "https.*$", clusterUrl)

--- a/test/terraform_azure_test.go
+++ b/test/terraform_azure_test.go
@@ -2,37 +2,42 @@ package test
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/environment"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func TestTerraformAzure(t *testing.T) {
+	t.Parallel()
+
 	environment.RequireEnvVar(t, "AZURE_TEST_SUBSCRIPTION_ID")
 
 	// UniqueId() can return an ID starting with a digit, but Azure requires a
 	// letter as the first character, so we always prepend one.
-	projectName := fmt.Sprintf("a%s", random.UniqueId())
+	projectName := fmt.Sprintf("a%s", random.UniqueID())
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../azure",
-		Vars: map[string]interface{}{
+		Vars: map[string]any{
 			"subscription_id": os.Getenv("AZURE_TEST_SUBSCRIPTION_ID"),
 			"crate":           "{heap_size_gb = 2, cluster_name = \"cratedb\", cluster_size = 2, ssl_enable = true}",
 			"config":          fmt.Sprintf("{project_name = \"%s\", environment = \"test\", owner = \"Crate.IO\", team = \"Test Team\", location = \"westeurope\", zone = 1}", projectName),
 		},
 	})
 
-	defer terraform.Destroy(t, terraformOptions)
-	terraform.InitAndApply(t, terraformOptions)
+	// Clean up resources with "terraform destroy" at the end of the test.
+	defer terraform.DestroyContext(t, t.Context(), terraformOptions)
 
-	clusterUrl := terraform.Output(t, terraformOptions, "cratedb_application_url")
-	clusterUrlIp := terraform.Output(t, terraformOptions, "cratedb_application_url_ip")
-	cratedbUsername := terraform.Output(t, terraformOptions, "cratedb_username")
-	cratedbPassword := terraform.Output(t, terraformOptions, "cratedb_password")
+	terraform.InitAndApplyContext(t, t.Context(), terraformOptions)
+
+	clusterUrl := terraform.OutputContext(t, t.Context(), terraformOptions, "cratedb_application_url")
+	clusterUrlIp := terraform.OutputContext(t, t.Context(), terraformOptions, "cratedb_application_url_ip")
+	cratedbUsername := terraform.OutputContext(t, t.Context(), terraformOptions, "cratedb_username")
+	cratedbPassword := terraform.OutputContext(t, t.Context(), terraformOptions, "cratedb_password")
 
 	// we don't validate the certificate explicitly, but check that the URL includes https
 	assert.Regexp(t, "https.*$", clusterUrl)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

A few additions/improvements to the Azure setup:

1. Use a more convenient approach for SSH keys by reusing a user's existing public key rather than creating a new key pair for every new deployment
2. Open JMX/node_exporter metrics for Prometheus scraping
3. Optionally add the Pyroscope agent
4. Fixed an issue that prevented the data disk from being mounted correctly

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #???
